### PR TITLE
Add test for Ember 3.1 ES5 getters

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@ember-decorators/utils": "^2.0.0",
     "ember-cli-babel": "^6.6.0",
-    "ember-compatibility-helpers": "^0.1.3"
+    "ember-compatibility-helpers": "^1.0.0-beta.2"
   },
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^2.0.0",

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -1,10 +1,10 @@
 import { module, test } from 'ember-qunit';
-import { get, set, setProperties } from '@ember/object';
+import EmberObject, { get, set, setProperties } from '@ember/object';
 
 import { computed, readOnly } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
 
-import { SUPPORTS_NEW_COMPUTED } from 'ember-compatibility-helpers';
+import { SUPPORTS_NEW_COMPUTED, HAS_NATIVE_COMPUTED_GETTERS } from 'ember-compatibility-helpers';
 
 module('javascript | @computed', function() {
 
@@ -199,6 +199,26 @@ module('javascript | @computed', function() {
       /ES6 property getters\/setters only need to be decorated once, 'fullName' was decorated on both the getter and the setter/
     );
   });
+
+  if (HAS_NATIVE_COMPUTED_GETTERS) {
+    test('Native computed getters work with decorators', function(assert) {
+      class Foo extends EmberObject {
+        constructor() {
+          super(...arguments);
+          this.first = 'rob';
+          this.last = 'jackson';
+        }
+
+        @computed('first', 'last')
+        get fullName() {
+          return `${this.first} ${this.last}`;
+        }
+      }
+
+      let obj = Foo.create();
+      assert.strictEqual(get(obj, 'fullName'), obj.fullName, 'ES5 getter equals equivalent get()');
+    });
+  }
 
   module('@readOnly', function() {
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,9 +63,9 @@
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.1.0"
 
-"@ember-decorators/utils@^2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-2.0.0-beta.3.tgz#1a66c8413f6622b2d4da4f35801a94ee5a1ee176"
+"@ember-decorators/utils@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-2.0.0.tgz#14f1fbd6de4f1d722b15c155287aafc6453943f2"
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-compatibility-helpers "1.0.0-beta.1"
@@ -2327,9 +2327,9 @@ ember-compatibility-helpers@1.0.0-beta.1:
     ember-cli-version-checker "^2.0.0"
     semver "^5.4.1"
 
-ember-compatibility-helpers@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.3.tgz#039a57e9f1a401efda0023c1e3650bd01cfd7087"
+ember-compatibility-helpers@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.0.0-beta.2.tgz#00cb134af45f9562fa47a23f4da81a63aad41943"
   dependencies:
     babel-plugin-debug-macros "^0.1.11"
     ember-cli-version-checker "^2.0.0"


### PR DESCRIPTION
One potential addition would be to test the "else" case, where ES5 getters are not defined -- can we assert that the values would be different? I'm not sure.